### PR TITLE
Update to WCSim v1.12.29

### DIFF
--- a/app/application/appHKHybridSingleEvent.cc
+++ b/app/application/appHKHybridSingleEvent.cc
@@ -38,6 +38,7 @@ int main(int argc, char **argv)
     MDT->RegisterPMTType(fPMTType[1], new Response3inchR14374());
 
     const vector<string> listWCRootEvt{"wcsimrootevent", "wcsimrootevent2"};
+    const vector<string> listWCRootCopyTree{"wcsimGeoT","Settings","wcsimRootOptionsT"};
 
     WCRootData *inData = new WCRootData();
     WCRootData *outData = new WCRootData();
@@ -59,11 +60,14 @@ int main(int argc, char **argv)
             inData->AddTrueHitsToMDT(MDT->GetHitTubeCollection(fPMTType[j]), MDT->GetPMTResponse(fPMTType[j]), toffset, j);
             MDT->DoAddDark(fPMTType[j]);
             MDT->DoDigitize(fPMTType[j]);
-            MDT->DoTrigger(fPMTType[j]);
-
-            TriggerInfo *ti = MDT->GetTriggerInfo(fPMTType[j]);
-            outData->AddDigiHits(MDT->GetHitTubeCollection(fPMTType[j]), ti, iEntry, j);
         }
+        
+        // !!!!!!!!!!! Trigger is done only for the 20'' PMT, and the digi hits of both PMT types are added based on that !!!!!!!!!!!
+        MDT->DoTrigger(fPMTType[0]);
+        TriggerInfo* ti20 = MDT->GetTriggerInfo(fPMTType[0]);
+        outData->AddDigiHits(MDT->GetHitTubeCollection(fPMTType[0]), ti20, iEntry, 0);
+        outData->AddDigiHits(MDT->GetHitTubeCollection(fPMTType[1]), ti20, iEntry, 1);
+
         outData->FillTree();
 
         MDT->DoInitialize();
@@ -97,3 +101,4 @@ bool ParseCmdArguments(int argc, char **argv)
 	}
 	return true;
 }
+

--- a/app/utilities/WCRootData/src/WCRootData.cc
+++ b/app/utilities/WCRootData/src/WCRootData.cc
@@ -236,6 +236,8 @@ void WCRootData::AddDigiHits(MDTManager *mdt, int eventID, int iPMT)
 void WCRootData::AddDigiHits(HitTubeCollection *hc, TriggerInfo *ti, int eventID, int iPMT)
 {
     WCSimRootTrigger* anEvent = fSpEvt[iPMT]->GetTrigger(0);
+    //first trigger has SubEvtNumber=1
+    anEvent->SetHeader(eventID, 0, 0, 1);
     // Save raw hits
     // container for photon info
     std::vector<double> truetime;
@@ -439,6 +441,28 @@ void WCRootData::FillTree()
 void WCRootData::AddTracks(const WCSimRootTrigger *aEvtIn, float offset_time, int iPMT)
 {
     WCSimRootTrigger *aEvtOut = fSpEvt[iPMT]->GetTrigger(0);
+        
+    // Copy truth info (Npar, Nvtxs, Jmu, Jp, Vtxs, Modes, Vtxsvol)
+    int nv = aEvtIn->GetNvtxs();
+    if (nv < 0) nv = 0;
+    if (nv > 900) nv = 900;
+    if (aEvtIn->GetNvtxs() < 0 || aEvtIn->GetNvtxs() > MAX_N_VERTICES) {
+        std::cerr << "WARN Nvtxs=" << aEvtIn->GetNvtxs() << "\n";
+    }
+    aEvtOut->SetNpar(aEvtIn->GetNpar());
+    aEvtOut->SetNvtxs(nv);
+    aEvtOut->SetVecRecNumber(aEvtIn->GetVecRecNumber());
+    aEvtOut->SetJmu(aEvtIn->GetJmu());
+    aEvtOut->SetJp(aEvtIn->GetJp());
+
+    for (int iv = 0; iv < nv; ++iv) {
+        aEvtOut->SetMode(iv, aEvtIn->GetMode(iv));
+        aEvtOut->SetVtxsvol(iv, aEvtIn->GetVtxsvol(iv));
+        for (int i = 0; i < 4; ++i) {
+            aEvtOut->SetVtxs(iv, i, aEvtIn->GetVtxs(iv, i));
+        }
+    }
+
     TClonesArray *tracks = aEvtIn->GetTracks();
     const int ntrack = tracks->GetEntries();
     for(int i=0; i<ntrack; i++)

--- a/app/utilities/WCRootData/src/WCRootData.cc
+++ b/app/utilities/WCRootData/src/WCRootData.cc
@@ -102,9 +102,11 @@ void WCRootData::AddTrueHitsToMDT(HitTubeCollection *hc, PMTResponse *pr, float 
             for(int k=0; k<3; k++){ th->SetPosition(k, aHitTime->GetPhotonEndPos(k)); }
             for(int k=0; k<3; k++){ th->SetDirection(k, aHitTime->GetPhotonEndDir(k)); }
             for(int k=0; k<3; k++){ th->SetStartDirection(k, aHitTime->GetPhotonStartDir(k)); }
-
+            
             th->SetStartTime(aHitTime->GetPhotonStartTime()+intTime);
             for(int k=0; k<3; k++){ th->SetStartPosition(k, aHitTime->GetPhotonStartPos(k)); }
+            th->SetStartEnergy(aHitTime->GetPhotonStartEnergy());
+            th->SetEnergy(aHitTime->GetPhotonEndEnergy());
             th->SetCreatorProcess((int)(aHitTime->GetPhotonCreatorProcess()));
             if( !pr->ApplyDE(th,&(*hc)[tubeID]) ){ continue; }
 
@@ -239,6 +241,8 @@ void WCRootData::AddDigiHits(HitTubeCollection *hc, TriggerInfo *ti, int eventID
     std::vector<double> truetime;
     std::vector<int>   primaryParentID;
     std::vector<float> photonStartTime;
+    std::vector<float> photonStartEnergy;
+    std::vector<float> photonEndEnergy;
     std::vector<TVector3> photonStartPos;
     std::vector<TVector3> photonEndPos;
     std::vector<TVector3> photonStartDir;
@@ -260,6 +264,8 @@ void WCRootData::AddDigiHits(HitTubeCollection *hc, TriggerInfo *ti, int eventID
             truetime.push_back(PEs[iPE]->GetTime());
             primaryParentID.push_back(PEs[iPE]->GetParentId());
             photonStartTime.push_back(PEs[iPE]->GetStartTime());
+            photonStartEnergy.push_back(PEs[iPE]->GetStartEnergy());
+            photonEndEnergy.push_back(PEs[iPE]->GetEnergy());
             photonStartPos.push_back(TVector3(PEs[iPE]->GetStartPosition(0),PEs[iPE]->GetStartPosition(1),PEs[iPE]->GetStartPosition(2)));
             photonEndPos.push_back(TVector3(PEs[iPE]->GetPosition(0),PEs[iPE]->GetPosition(1),PEs[iPE]->GetPosition(2)));
             photonStartDir.push_back(TVector3(PEs[iPE]->GetStartDirection(0),PEs[iPE]->GetStartDirection(1),PEs[iPE]->GetStartDirection(2)));
@@ -273,6 +279,8 @@ void WCRootData::AddDigiHits(HitTubeCollection *hc, TriggerInfo *ti, int eventID
                                 truetime,
                                 primaryParentID,
                                 photonStartTime,
+                                photonStartEnergy,
+                                photonEndEnergy,
                                 photonStartPos,
                                 photonEndPos,
                                 photonStartDir,
@@ -282,6 +290,8 @@ void WCRootData::AddDigiHits(HitTubeCollection *hc, TriggerInfo *ti, int eventID
         truetime.clear();
         primaryParentID.clear();
         photonStartTime.clear();
+        photonStartEnergy.clear();
+        photonEndEnergy.clear();
         photonStartPos.clear();
         photonEndPos.clear();
         photonStartDir.clear();

--- a/cpp/include/TrueHit.h
+++ b/cpp/include/TrueHit.h
@@ -11,17 +11,21 @@ class TrueHit
         float GetParentId() const { return fParentId; }
         float GetPosition(int i) const { return fPosition[i]; }
         float GetDirection(int i) const { return fDirection[i]; }
+        float GetEnergy() const { return fEnergy; }
         float GetStartTime() const {return fStartTime; }
         float GetStartPosition(int i) const { return fStartPosition[i]; }
         float GetStartDirection(int i) const { return fStartDirection[i]; }
+        float GetStartEnergy() const { return fStartEnergy; }
         int GetPosBin(int i) const { return fBin[i]; }
         int GetCreatorProcess() const { return fCreatorProcess; }
 
         void SetPosition(int i, float f) { fPosition[i] = f; }
         void SetDirection(int i, float f) { fDirection[i] = f; }
+        void SetEnergy(float f) { fEnergy = f; } 
         void SetStartTime(float f) { fStartTime = f; }
         void SetStartPosition(int i, float f) { fStartPosition[i] = f; }
         void SetStartDirection(int i, float f) { fStartDirection[i] = f; }
+        void SetStartEnergy(float f) { fStartEnergy = f; }
         void SetPosBin(int i, int b){ fBin[i] = b; }
         void SetCreatorProcess(int i){ fCreatorProcess = i; }
 
@@ -29,9 +33,11 @@ class TrueHit
         double fTime;
         float fPosition[3]; // Hit position on photocade
         float fDirection[3]; // Direction of photon hitting photocathode
+        float fEnergy;
         float fStartTime; // Photon track initial time
         float fStartPosition[3]; // Photon track initial position
         float fStartDirection[3]; // Photon track initial direction
+        float fStartEnergy; 
         int fParentId;
         int fBin[3];
         int fCreatorProcess;


### PR DESCRIPTION
This should be merged after PR https://github.com/hyperk/MDT/pull/10 (duplicating https://github.com/hyperk/MDT/pull/11)
---
Thanks to development from @cshuoyu

Major changes
- Compatibility update to WCSim v1.12.29 (new start and new energy for true photon hit)
- Set first trigger SubEvtNumber=1, copy truth vertex infor
- Change trigger logic for HK far detector